### PR TITLE
Use Debian instead of Alpine Linux

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM node:8.15-alpine
+FROM node:8.15
 
 # Speed up NPM by preventing it from displaying progress
 RUN npm set progress=false \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,18 +2,15 @@ FROM olliecaine/base:master
 
 WORKDIR /project
 
-# Install Chrome
-RUN apk update && apk upgrade \
-    && echo @edge http://nl.alpinelinux.org/alpine/v3.8/community >> /etc/apk/repositories \
-    && echo @edge http://nl.alpinelinux.org/alpine/v3.8/main >> /etc/apk/repositories \
-    && apk add --no-cache \
-      chromium \
-      nss \
-      make@edge \
-      python@edge \      
-      freetype@edge \
-      harfbuzz@edge \
-      ttf-freefont@edge \
-      freetype-dev@edge
-ENV CHROME_BIN=/usr/bin/chromium-browser \
-    CHROME_PATH=/usr/lib/chromium/    
+# OPTIONAL: Install dumb-init (Very handy for easier signal handling of SIGINT/SIGTERM/SIGKILL etc.)
+RUN wget https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb
+RUN dpkg -i dumb-init_*.deb
+ENTRYPOINT ["dumb-init"]
+
+# Use new sources since Jessie has been archived
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
+# Install Google Chrome
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN apt-get update && apt-get install -y google-chrome-stable


### PR DESCRIPTION
The project uses Alpine now, I assume the reason why is to have
a more resource efficient Docker container.

This fixes the issue with Chrome not starting properly when using Karma.
Alpine Linux is great for small Docker images, buzzword friendly
and all, but tends to be quite poorly supported by Google Chrome.
(It's a hack at best. Running Google Chrome inside a Docker container
is quite a stretch in the first place, it's not exactly how Chrome was
designed to run...)

Although it seems to be possible to run Chrome in Alpine as well,
that method introduces its own bunch of problems, and when it's really
acting up, consider that the time a person spends debugging stuff is
much more valuable than the time and CPU Alpine Linux will save you
compared to a Debian-based image.